### PR TITLE
Adjust license header

### DIFF
--- a/src/main/java/SaslPrep.java
+++ b/src/main/java/SaslPrep.java
@@ -1,12 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Software which is licensed under the Apache License v2.0 should use another kind of header, see http://www.apache.org/foundation/license-faq.html#Apply-My-Software for further details.
You might want to add an additional copyright note as well at the very beginning like the following

Copyright [yyyy] [name of copyright owner]