### PR TITLE
fix typo in private use check

### DIFF
--- a/src/main/java/SaslPrep.java
+++ b/src/main/java/SaslPrep.java
@@ -238,7 +238,7 @@ public class SaslPrep {
      */
     private static boolean privateUse(int codepoint) {
         return 0xE000 <= codepoint && codepoint <= 0xF8FF
-                || 0xF000 <= codepoint && codepoint <= 0xFFFFD
+                || 0xF0000 <= codepoint && codepoint <= 0xFFFFD
                 || 0x100000 <= codepoint && codepoint <= 0x10FFFD;
     }
 


### PR DESCRIPTION
See also https://issues.apache.org/jira/browse/PDFBOX-4587 and related TIKA issue, u2070E was considered "private use".